### PR TITLE
Use JSON Compliant Copy of MsGraph OpenAPI Document

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/CalendarPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/CalendarPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/CalendarPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/CalendarPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/ContactsPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/ContactsPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/ContactsPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/ContactsPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/DriveItemPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/DriveItemPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/DriveItemPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/DriveItemPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MePlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MePlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MePlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MePlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MessagesPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MessagesPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MessagesPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MessagesPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/semantic-kernel/feature/api-manifest/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MsGraphOpenApiV1.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelJsonSchema.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelJsonSchema.cs
@@ -14,6 +14,8 @@ public sealed class KernelJsonSchema
 {
     /// <summary>Converter for serializing/deserializing JsonSchema instances.</summary>
     private static readonly SchemaJsonConverter s_jsonSchemaConverter = new();
+    /// <summary>Serialization settings for <see cref="JsonSerializer"/></summary>
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new() { MaxDepth = 128 };
     /// <summary>The schema stored as a string.</summary>
     private string? _schemaAsString;
 
@@ -21,7 +23,7 @@ public sealed class KernelJsonSchema
     /// <param name="jsonSchema">The JSON Schema as a string.</param>
     /// <returns>A parsed <see cref="KernelJsonSchema"/>, or null if <paramref name="jsonSchema"/> is null or empty.</returns>
     internal static KernelJsonSchema? ParseOrNull(string? jsonSchema) =>
-        !string.IsNullOrEmpty(jsonSchema) ? new(JsonSerializer.Deserialize<JsonElement>(jsonSchema!)) :
+        !string.IsNullOrEmpty(jsonSchema) ? new(JsonSerializer.Deserialize<JsonElement>(jsonSchema!, s_jsonSerializerOptions)) :
         null;
 
     /// <summary>Parses a JSON Schema for a parameter type.</summary>
@@ -30,21 +32,21 @@ public sealed class KernelJsonSchema
     /// <exception cref="ArgumentException"><paramref name="jsonSchema"/> is null.</exception>
     /// <exception cref="JsonException">The JSON is invalid.</exception>
     public static KernelJsonSchema Parse(string jsonSchema) =>
-        new(JsonSerializer.SerializeToElement(JsonSchema.FromText(jsonSchema)));
+        new(JsonSerializer.SerializeToElement(JsonSchema.FromText(jsonSchema, s_jsonSerializerOptions), s_jsonSerializerOptions));
 
     /// <summary>Parses a JSON Schema for a parameter type.</summary>
     /// <param name="jsonSchema">The JSON Schema as a sequence of UTF16 chars.</param>
     /// <returns>A parsed <see cref="KernelJsonSchema"/>.</returns>
     /// <exception cref="JsonException">The JSON is invalid.</exception>
     public static KernelJsonSchema Parse(ReadOnlySpan<char> jsonSchema) =>
-        new(JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonSchema>(jsonSchema)));
+        new(JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonSchema>(jsonSchema, s_jsonSerializerOptions), s_jsonSerializerOptions));
 
     /// <summary>Parses a JSON Schema for a parameter type.</summary>
     /// <param name="utf8JsonSchema">The JSON Schema as a sequence of UTF8 bytes.</param>
     /// <returns>A parsed <see cref="KernelJsonSchema"/>.</returns>
     /// <exception cref="JsonException">The JSON is invalid.</exception>
     public static KernelJsonSchema Parse(ReadOnlySpan<byte> utf8JsonSchema) =>
-        new(JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonSchema>(utf8JsonSchema)));
+        new(JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonSchema>(utf8JsonSchema, s_jsonSerializerOptions), s_jsonSerializerOptions));
 
     /// <summary>Initializes a new instance from the specified <see cref="JsonElement"/>.</summary>
     /// <param name="jsonSchema">The schema to be stored.</param>


### PR DESCRIPTION
Fixes #27 by:
- Updates `apiDescriptionUrl` in apiManifest files to use JSON compliant OpenAPI document. The compliant OpenAPI document stringifys the problematic values identified at https://github.com/microsoftgraph/semantic-kernel/issues/20. This is just a temporary fix.
- Increases the max depth of JsonSerializer in KernelJsonSchema to handle large schema in MS Graph API. For example, `DriveItem`.
