### PR TITLE
Bump Microsoft.OpenApi version to 1.6.12.

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -62,8 +62,8 @@
     <PackageVersion Include="Microsoft.Graph" Version="[4.51.0, 5)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="[3.32.3, )" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="[2.28.0, )" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="[1.6.11, )" />
-    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="[1.6.11, )" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="[1.6.12, )" />
+    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="[1.6.12, )" />
     <PackageVersion Include="Newtonsoft.Json" Version="[13.0.3, )" />
     <PackageVersion Include="Google.Apis.CustomSearchAPI.v1" Version="[1.60.0.3001, )" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.60.0" />

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/CalendarPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/CalendarPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/ContactsPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/ContactsPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/DriveItemPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/DriveItemPlugin/apimanifest.json
@@ -6,15 +6,15 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",
-          "uriTemplate": "/drive/root/children/{driveItem-id}/content"
+          "uriTemplate": "/me/drive/root/children/{driveItem-id}/content"
         },
         {
           "method": "Get",
-          "uriTemplate": "/drive/root/children/{driveItem-id}"
+          "uriTemplate": "/me/drive/root/children/{driveItem-id}"
         }
       ]
     }

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/DriveItemPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/DriveItemPlugin/apimanifest.json
@@ -10,11 +10,11 @@
       "requests": [
         {
           "method": "Get",
-          "uriTemplate": "/me/drive/root/children/{driveItem-id}/content"
+          "uriTemplate": "/drive/root/children/{driveItem-id}/content"
         },
         {
           "method": "Get",
-          "uriTemplate": "/me/drive/root/children/{driveItem-id}"
+          "uriTemplate": "/drive/root/children/{driveItem-id}"
         }
       ]
     }

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MePlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MePlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",

--- a/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MessagesPlugin/apimanifest.json
+++ b/dotnet/samples/KernelSyntaxExamples/ApiManifestPlugins/MessagesPlugin/apimanifest.json
@@ -6,7 +6,7 @@
   },
   "apiDependencies": {
     "microsoft.graph": {
-      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/JsonCompliant/openapi/v1.0/graphexplorer.yaml",
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/graphexplorer.yaml",
       "requests": [
         {
           "method": "Get",


### PR DESCRIPTION
This PR fixes #20 by bumping `Microsoft.OpenApi` and `Microsoft.OpenApi.Readers` to `1.6.12`. [Microsoft.OpenApi v1.6.12](https://github.com/microsoft/OpenAPI.NET/releases/tag/1.6.12) fixes the non-standard JSON values that were emitted by the OpenApiJsonWritter.