### PR TITLE
Address PR comments

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example99_ApiManifest.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example99_ApiManifest.cs
@@ -92,12 +92,6 @@ public class Example99_ApiManifest : BaseTest
             throw new InvalidOperationException("Missing Scopes configuration for Microsoft Graph API.");
         }
 
-        string? currentAssemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        if (string.IsNullOrWhiteSpace(currentAssemblyDirectory))
-        {
-            throw new InvalidOperationException("Unable to determine current assembly directory.");
-        }
-
         LocalUserMSALCredentialManager credentialManager = await LocalUserMSALCredentialManager.CreateAsync().ConfigureAwait(false);
 
         var token = await credentialManager.GetTokenAsync(


### PR DESCRIPTION
- Addresses comments: https://github.com/microsoft/semantic-kernel/pull/4662
- Renames `apiManifestFilePath` to `filePath`
- Removes dead code
- Uses DocumentLoader whenever possible
- Syncs `EnableDynamicPayload` default to other instances in the file.